### PR TITLE
Settings Page Header Options Clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ The plugin is lightweight and only loads the necessary code on the frontend. It 
 
 ## Changelog
 
+### 1.2.3
+* Header Placement Clarification on Options Page
 ### 1.2.2
 * settings page text area visibility improvement
 ### 1.2.1
-* prefix imwz
+* prefix iwz
 * additional renaming
 
 ### 1.2.0

--- a/includes/class-banner-container-settings.php
+++ b/includes/class-banner-container-settings.php
@@ -39,7 +39,7 @@ class IWZ_Banner_Container_Settings {
      */
     public function register_banner_locations() {
         $this->banner_locations = array(
-            'wp_head' => __('Header (Before </head>)', 'banner-container-plugin'),
+            'wp_head' => __('Top of Page (After <body>)', 'banner-container-plugin'),
             'wp_footer' => __('Footer (Before </body>)', 'banner-container-plugin'),
             'the_content' => __('Within Content', 'banner-container-plugin'),
             'get_sidebar' => __('Before Sidebar', 'banner-container-plugin'),

--- a/iwz-banner-container-plugin.php
+++ b/iwz-banner-container-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Banner Container Plugin
  * Plugin URI: https://imagewize.com/iwz-banner-container-plugin
  * Description: Add banners to different locations in your WordPress theme.
- * Version: 1.2.2
+ * Version: 1.2.3
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * License: GPL-2.0+


### PR DESCRIPTION
This pull request updates the `register_banner_locations` method in the `includes/class-banner-container-settings.php` file to improve the clarity of banner placement descriptions.

### Updates to banner placement descriptions:
* Modified the label for the `wp_head` location from "Header (Before `</head>`)" to "Top of Page (After `<body>`)" for better accuracy and user understanding.